### PR TITLE
Make it possible to set a specific background corner radius 

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Include a `NachoTextView` in your xml layout as follows:
 NachoTextView offers several custom attributes that allow you to control the appearance of the chips it creates:
 * `chipSpacing` - The horizontal space between chips
 * `chipBackground` - The background color of the chip, can be a ColorStateList to change color when the chip is clicked
+* `chipCornerRadius` - The corner radius of the chip background
 * `chipTextColor` - The color of the chip text
 * `chipTextSize` - The font size of the chip text
 * `chipHeight` - The height of a single chip

--- a/nachos/src/main/java/com/hootsuite/nachos/ChipConfiguration.java
+++ b/nachos/src/main/java/com/hootsuite/nachos/ChipConfiguration.java
@@ -6,6 +6,7 @@ public class ChipConfiguration {
 
     private final int mChipSpacing;
     private final ColorStateList mChipBackground;
+    private final int mChipCornerRadius;
     private final int mChipTextColor;
     private final int mChipTextSize;
     private final int mChipHeight;
@@ -18,6 +19,7 @@ public class ChipConfiguration {
      *
      * @param chipSpacing         the amount of horizontal space (in pixels) to put between consecutive chips
      * @param chipBackground      the {@link ColorStateList} to set as the background of the chips
+     * @param chipCornerRadius    the corner radius of the chip background, in pixels
      * @param chipTextColor       the color to set as the text color of the chips
      * @param chipTextSize        the font size (in pixels) to use for the text of the chips
      * @param chipHeight          the height (in pixels) of each chip
@@ -26,6 +28,7 @@ public class ChipConfiguration {
      */
     ChipConfiguration(int chipSpacing,
                       ColorStateList chipBackground,
+                      int chipCornerRadius,
                       int chipTextColor,
                       int chipTextSize,
                       int chipHeight,
@@ -33,6 +36,7 @@ public class ChipConfiguration {
                       int maxAvailableWidth) {
         mChipSpacing = chipSpacing;
         mChipBackground = chipBackground;
+        mChipCornerRadius = chipCornerRadius;
         mChipTextColor = chipTextColor;
         mChipTextSize = chipTextSize;
         mChipHeight = chipHeight;
@@ -46,6 +50,10 @@ public class ChipConfiguration {
 
     public ColorStateList getChipBackground() {
         return mChipBackground;
+    }
+
+    public int getChipCornerRadius() {
+        return mChipCornerRadius;
     }
 
     public int getChipTextColor() {

--- a/nachos/src/main/java/com/hootsuite/nachos/NachoTextView.java
+++ b/nachos/src/main/java/com/hootsuite/nachos/NachoTextView.java
@@ -9,6 +9,7 @@ import android.graphics.Paint;
 import android.support.annotation.ColorInt;
 import android.support.annotation.ColorRes;
 import android.support.annotation.DimenRes;
+import android.support.annotation.Dimension;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.content.ContextCompat;
@@ -68,6 +69,7 @@ import java.util.Map;
  *     <ul>
  *         <li>chipSpacing - the horizontal space between chips</li>
  *         <li>chipBackground - the background color of the chip</li>
+ *         <li>chipCornerRadius - the corner radius of the chip background</li>
  *         <li>chipTextColor - the color of the chip text</li>
  *         <li>chipTextSize - the font size of the chip text</li>
  *         <li>chipHeight - the height of a single chip</li>
@@ -123,6 +125,7 @@ public class NachoTextView extends MultiAutoCompleteTextView implements TextWatc
     // UI Attributes
     private int mChipSpacing = -1;
     private ColorStateList mChipBackground = null;
+    private int mChipCornerRadius = -1;
     private int mChipTextColor = -1;
     private int mChipTextSize = -1;
     private int mChipHeight = -1;
@@ -195,6 +198,7 @@ public class NachoTextView extends MultiAutoCompleteTextView implements TextWatc
             try {
                 mChipSpacing = attributes.getDimensionPixelSize(R.styleable.NachoTextView_chipSpacing, -1);
                 mChipBackground = attributes.getColorStateList(R.styleable.NachoTextView_chipBackground);
+                mChipCornerRadius = attributes.getDimensionPixelSize(R.styleable.NachoTextView_chipCornerRadius, -1);
                 mChipTextColor = attributes.getColor(R.styleable.NachoTextView_chipTextColor, -1);
                 mChipTextSize = attributes.getDimensionPixelSize(R.styleable.NachoTextView_chipTextSize, -1);
                 mChipHeight = attributes.getDimensionPixelSize(R.styleable.NachoTextView_chipHeight, -1);
@@ -306,6 +310,34 @@ public class NachoTextView extends MultiAutoCompleteTextView implements TextWatc
         mChipBackground = chipBackground;
         invalidateChips();
     }
+
+    /**
+     * @return The chip background corner radius value, in pixels.
+     */
+    @Dimension
+    public int getChipCornerRadius() {
+        return mChipCornerRadius;
+    }
+
+    /**
+     * Sets the chip background corner radius.
+     *
+     * @param chipCornerRadiusResId The dimension resource with the corner radius value.
+     */
+    public void setChipCornerRadiusResource(@DimenRes int chipCornerRadiusResId) {
+        setChipCornerRadius(getContext().getResources().getDimensionPixelSize(chipCornerRadiusResId));
+    }
+
+    /**
+     * Sets the chip background corner radius.
+     *
+     * @param chipCornerRadius The corner radius value, in pixels.
+     */
+    public void setChipCornerRadius(@Dimension int chipCornerRadius) {
+        mChipCornerRadius = chipCornerRadius;
+        invalidateChips();
+    }
+
 
     public int getChipTextColor() {
         return mChipTextColor;
@@ -435,6 +467,7 @@ public class NachoTextView extends MultiAutoCompleteTextView implements TextWatc
             ChipConfiguration configuration = new ChipConfiguration(
                     mChipSpacing,
                     mChipBackground,
+                    mChipCornerRadius,
                     mChipTextColor,
                     mChipTextSize,
                     mChipHeight,

--- a/nachos/src/main/java/com/hootsuite/nachos/chip/ChipSpan.java
+++ b/nachos/src/main/java/com/hootsuite/nachos/chip/ChipSpan.java
@@ -9,6 +9,7 @@ import android.graphics.Paint;
 import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
+import android.support.annotation.Dimension;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.content.ContextCompat;
@@ -56,6 +57,7 @@ public class ChipSpan extends ImageSpan implements Chip {
     private ColorStateList mDefaultBackgroundColor;
     private ColorStateList mBackgroundColor;
     private int mTextColor;
+    private int mCornerRadius = -1;
     private int mIconBackgroundColor;
 
     private int mTextSize = -1;
@@ -122,6 +124,7 @@ public class ChipSpan extends ImageSpan implements Chip {
         mDefaultBackgroundColor = chipSpan.mDefaultBackgroundColor;
         mTextColor = chipSpan.mTextColor;
         mIconBackgroundColor = chipSpan.mIconBackgroundColor;
+        mCornerRadius = chipSpan.mCornerRadius;
 
         mTextSize = chipSpan.mTextSize;
         mPaddingEdgePx = chipSpan.mPaddingEdgePx;
@@ -226,6 +229,15 @@ public class ChipSpan extends ImageSpan implements Chip {
      */
     public void setBackgroundColor(@Nullable ColorStateList backgroundColor) {
         mBackgroundColor = backgroundColor != null ? backgroundColor : mDefaultBackgroundColor;
+    }
+
+    /**
+     * Sets the chip background corner radius.
+     *
+     * @param cornerRadius The corner radius value, in pixels.
+     */
+    public void setCornerRadius(@Dimension int cornerRadius) {
+        mCornerRadius = cornerRadius;
     }
 
     /**
@@ -404,7 +416,7 @@ public class ChipSpan extends ImageSpan implements Chip {
         paint.setColor(backgroundColor);
         int height = calculateChipHeight(top, bottom);
         RectF rect = new RectF(x, top, x + mChipWidth, bottom);
-        int cornerRadius = height / 2;
+        int cornerRadius = (mCornerRadius != -1) ? mCornerRadius : height / 2;
         canvas.drawRoundRect(rect, cornerRadius, cornerRadius, paint);
         paint.setColor(mTextColor);
     }

--- a/nachos/src/main/java/com/hootsuite/nachos/chip/ChipSpanChipCreator.java
+++ b/nachos/src/main/java/com/hootsuite/nachos/chip/ChipSpanChipCreator.java
@@ -22,6 +22,7 @@ public class ChipSpanChipCreator implements ChipCreator<ChipSpan> {
     public void configureChip(@NonNull ChipSpan chip, @NonNull ChipConfiguration chipConfiguration) {
         int chipSpacing = chipConfiguration.getChipSpacing();
         ColorStateList chipBackground = chipConfiguration.getChipBackground();
+        int chipCornerRadius = chipConfiguration.getChipCornerRadius();
         int chipTextColor = chipConfiguration.getChipTextColor();
         int chipTextSize = chipConfiguration.getChipTextSize();
         int chipHeight = chipConfiguration.getChipHeight();
@@ -34,6 +35,9 @@ public class ChipSpanChipCreator implements ChipCreator<ChipSpan> {
         }
         if (chipBackground != null) {
             chip.setBackgroundColor(chipBackground);
+        }
+        if (chipCornerRadius != -1) {
+            chip.setCornerRadius(chipCornerRadius);
         }
         if (chipTextColor != -1) {
             chip.setTextColor(chipTextColor);

--- a/nachos/src/main/res/values/attrs.xml
+++ b/nachos/src/main/res/values/attrs.xml
@@ -3,6 +3,7 @@
     <declare-styleable name="NachoTextView">
         <attr name="chipSpacing" format="reference|dimension" />
         <attr name="chipBackground" format="reference|color"/>
+        <attr name="chipCornerRadius" format="reference|dimension"/>
         <attr name="chipTextColor" format="reference|color"/>
         <attr name="chipTextSize" format="reference|dimension"/>
         <attr name="chipHeight" format="reference|dimension"/>

--- a/nachos/src/test/java/com/hootsuite/nachos/SpanChipTokenizerTest.java
+++ b/nachos/src/test/java/com/hootsuite/nachos/SpanChipTokenizerTest.java
@@ -745,7 +745,7 @@ public class SpanChipTokenizerTest extends TestCase {
     }
 
     private ChipConfiguration createTestChipConfiguration() {
-        return new ChipConfiguration(-1, null, -1, -1, -1, -1, -1);
+        return new ChipConfiguration(-1, null, -1, -1, -1, -1, -1, -1);
     }
 
     private SpannableStringBuilder createTestText(CharSequence[] evens, boolean chipifyEvens, CharSequence[] odds, boolean chipifyOdds) {


### PR DESCRIPTION
### Summary
Currently the background corner radius is based on the chip height `(height / 2)`. This PR adds a property and methods to allow changing the default value.

Although the [Material Design Chips](https://material.io/guidelines/components/chips.html) documentation only displays the chips with the same roundness, there's nothing explicitly documented about it, so I believe it'd be okay for the library to have some flexibility on that regard.
